### PR TITLE
converting the $persist collection to an array

### DIFF
--- a/src/RecentlyViewed.php
+++ b/src/RecentlyViewed.php
@@ -175,7 +175,7 @@ class RecentlyViewed
     public function mergePersistToCurrentSession(): RecentlyViewed
     {
         if ($viewer = $this->getViewer()) {
-            $persist = $viewer->getRecentViews();
+            $persist = $viewer->getRecentViews()->toArray();
             $session = session()->get(config('recently-viewed.session_prefix'));
             $merged  = [];
             if (is_array($session)) {


### PR DESCRIPTION
if (is_array($persist)) { //it returns always false, because $persist is a collection not an array