### PR TITLE
Remove non existent view loading

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -16,8 +16,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
             $this->registerMigrations();
         }
-
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'recently-viewed');
     }
 
     public function register()


### PR DESCRIPTION
remove view loading, to avoid error when caching views

eg `php artisan view:cache` causes error 
`/vendor/yaroslawww/laravel-recently-viewed/src/../resources/views" directory does not exist.`