### PR TITLE
Bumping Laravel 12 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^9.0|^10.0|^11.0"
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.25",


### PR DESCRIPTION
This pull request includes an update to the `composer.json` file to ensure compatibility with the latest version of the `illuminate/support` package.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L20-R20): Updated the `illuminate/support` dependency to include support for version 12.0.